### PR TITLE
fix: plugins dependencies in paper-plugin.yml

### DIFF
--- a/nova-loader/src/main/resources/paper-plugin.yml
+++ b/nova-loader/src/main/resources/paper-plugin.yml
@@ -7,20 +7,38 @@ bootstrapper: xyz.xenondevs.nova.loader.NovaBootstrapper
 main: xyz.xenondevs.nova.loader.NovaJavaPlugin
 load: STARTUP
 
-softdepend:
-  - WorldGuard
-  - GriefPrevention
-  - PlotSquared
-  - GriefDefender
-  - ProtectionStones
-  - Towny
-  - QuickShop
-  - Residence
-  - Vault
-  - ItemsAdder
-  - Oraxen
-  - MMOItems
-  - AuthMe
+dependencies:
+  server:
+    WorldGuard:
+      required: false
+    GriefPrevention:
+      required: false
+    PlotSquared:
+      required: false
+    GriefDefender:
+      required: false
+    ProtectionStones:
+      required: false
+    Towny:
+      required: false
+    QuickShop:
+      required: false
+    Residence:
+      required: false
+    Vault:
+      required: false
+    ItemsAdder:
+      required: false
+    Oraxen:
+      required: false
+    MMOItems:
+      required: false
+    AuthMe:
+      required: false
+    FastAsyncWorldEdit:
+      required: false
+    WorldEdit:
+      required: false
 
 permissions:
   nova.command.*:


### PR DESCRIPTION
Dependency configuration with paper is different from spigot.

To add a dependency to a spigot plugin :
```
softdepend:
  - MyPlugin
```

To add a dependency to a paper plugin :
```
dependencies:
  server:
    MyPlugin:
      required: false
```

Source :
- https://docs.papermc.io/paper/dev/getting-started/paper-plugins
- https://www.spigotmc.org/wiki/plugin-yml/
